### PR TITLE
Testing the thread per request benchmark

### DIFF
--- a/benchmarks/test/pom.xml
+++ b/benchmarks/test/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.officefloor.benchmarks</groupId>
@@ -15,6 +16,7 @@
 	<modules>
 		<module>woof_test</module>
 		<module>woof_benchmark_test</module>
+		<module>woof_tpr_test</module>
 		<module>woof_micro_test</module>
 		<module>woof_raw_test</module>
 		<module>woof_netty_test</module>
@@ -62,6 +64,11 @@
 			<dependency>
 				<groupId>net.officefloor.benchmarks</groupId>
 				<artifactId>woof_benchmark</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>net.officefloor.benchmarks</groupId>
+				<artifactId>woof_tpr</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>

--- a/benchmarks/test/woof_tpr_test/.gitignore
+++ b/benchmarks/test/woof_tpr_test/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings/
+/target/

--- a/benchmarks/test/woof_tpr_test/pom.xml
+++ b/benchmarks/test/woof_tpr_test/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>net.officefloor.benchmarks</groupId>
+		<artifactId>benchmarks_test</artifactId>
+		<version>1.0.0</version>
+	</parent>
+	<artifactId>woof_tpr_test</artifactId>
+	<dependencies>
+		<dependency>
+			<groupId>net.officefloor.benchmarks</groupId>
+			<artifactId>woof_tpr</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.officefloor.benchmarks</groupId>
+			<artifactId>woof_test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/benchmarks/test/woof_tpr_test/src/test/java/net/officefloor/benchmark/TestSuite.java
+++ b/benchmarks/test/woof_tpr_test/src/test/java/net/officefloor/benchmark/TestSuite.java
@@ -1,0 +1,38 @@
+/*
+ * OfficeFloor - http://www.officefloor.net
+ * Copyright (C) 2005-2018 Daniel Sagenschneider
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.officefloor.benchmark;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import net.officefloor.benchmark.DbTest;
+import net.officefloor.benchmark.FortunesTest;
+import net.officefloor.benchmark.JsonTest;
+import net.officefloor.benchmark.PlaintextTest;
+import net.officefloor.benchmark.QueriesTest;
+import net.officefloor.benchmark.UpdateTest;
+
+/**
+ * Tests.
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ JsonTest.class, DbTest.class, QueriesTest.class, FortunesTest.class, UpdateTest.class,
+		PlaintextTest.class })
+public class TestSuite {
+}

--- a/benchmarks/test/woof_tpr_test/src/test/resources/datasource.properties
+++ b/benchmarks/test/woof_tpr_test/src/test/resources/datasource.properties
@@ -1,0 +1,3 @@
+datasource.class = org.h2.jdbcx.JdbcDataSource
+url = jdbc:h2:mem:exampleDb
+user = sa


### PR DESCRIPTION
Provide thread-per-request benchmark as baseline to try to improve on performance (and also for seeing how much overhead the framework has against other thread-per-request models)