### PR TITLE
Eclipse plugins no code coverage

### DIFF
--- a/officefloor/eclipse/pom.xml
+++ b/officefloor/eclipse/pom.xml
@@ -92,6 +92,14 @@
 					</filesets>
 				</configuration>
 			</plugin>
+				<!-- Manual testing for code coverage -->
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			<plugin>
+			</plugin>
 			<plugin>
 				<!-- Use Tycho to build eclipse components -->
 				<groupId>org.eclipse.tycho</groupId>

--- a/officefloor/eclipse/pom.xml
+++ b/officefloor/eclipse/pom.xml
@@ -92,13 +92,13 @@
 					</filesets>
 				</configuration>
 			</plugin>
+			<plugin>
 				<!-- Manual testing for code coverage -->
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
-			<plugin>
 			</plugin>
 			<plugin>
 				<!-- Use Tycho to build eclipse components -->

--- a/officefloor/pom.xml
+++ b/officefloor/pom.xml
@@ -843,6 +843,11 @@
 					<artifactId>datanucleus-maven-plugin</artifactId>
 					<version>5.0.2</version>
 				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.2</version>
+				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings 
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
@@ -1353,7 +1358,6 @@
 						<!-- Code Coverage -->
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.2</version>
 						<executions>
 							<execution>
 								<goals>


### PR DESCRIPTION
As Eclipse plugins are manually tested, there are no tests for code coverage.   Therefore, should exclude the Eclipse plugins from code coverage to avoid incorrectly reporting no test coverage.