### PR TITLE
Fix build to handle bump in version

### DIFF
--- a/.travis-install.sh
+++ b/.travis-install.sh
@@ -4,4 +4,4 @@ set -e
 
 # Default Travix install except avoids archetype integration test also
 cd officefloor/bom
-mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Darchetype.test.skip=true -B -V
+mvn clean install -DskipTests=true -Dmaven.javadoc.skip=true -Darchetype.test.skip=true -B -V


### PR DESCRIPTION
Some clean parts of the build expect the maven-officefloor-plugin to be available (and potentially other aspects).   Rather than try to twist the clean to not require, the build stage should clean and build the system.

Note: for travis this is overly not necessary as fresh copy each time.   However, for Jenkins may reuse workspace.  Therefore, for consistence using the same "build" command in each environment.